### PR TITLE
Fixing Keystone URL

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-keystone_url: http://127.0.0.1:35357/v2.0
+keystone_url: http://127.0.0.1:35357/v3
 keystone_admin_token: ADMIN
 keystone_users:
   monasca-agent:


### PR DESCRIPTION
Ansible is pointing to the wrong Keystone URL for creating the keystone users.
