### PR TITLE
Compatibility fix with latest DevStack code

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Keystone User - Install dependencies
-  apt: name=python-keystoneclient state=present
+  pip: name=python-keystoneclient state=present
   when: not skip_install
 
 # These tasks need a Keystone v2 endpoint


### PR DESCRIPTION
Current pulls of DevStack fail with a NoSuchOptError exception when
attempting to log into the UI, due to an old version of
python-keystoneclient in Ubuntu Trusty's repo.  Switching to apt to
pip will ensure the latest keystoneclient and resolve this error.