### PR TITLE
Remove virtualenv install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Monasca Keystone
 Performs some Keystone setup for Monasca.
-The role requires python-keystoneclient and virtualenv be installed. By default it will use the virtualenv at monasca_virtualenv_dir.
+The role requires virtualenv be installed and will install python-keystoneclient. By default it will use the virtualenv at monasca_virtualenv_dir.
 This role adds one or more users/projects/roles to Keystone, as specified in keystone_users:
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 #Monasca Keystone
 Performs some Keystone setup for Monasca.
-The role requires python-keystoneclient and by default will use the version installed in the Monasca virtualenv.
+The role requires python-keystoneclient and virtualenv be installed. By default it will use the virtualenv at monasca_virtualenv_dir.
 This role adds one or more users/projects/roles to Keystone, as specified in keystone_users:
 
 ```

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,6 @@
 ---
-- include_vars: "{{ ansible_distribution }}.yml"
-
-- name: Install virtualenv
-  apt: name="{{ virtualenv_pkg }}" state=present
+- name: Keystone User - Install dependencies
+  pip: name=python-keystoneclient state=present virtualenv="{{monasca_virtualenv_dir}}"
   when: not skip_install
 
 - name: Install deps to avoid pip doing compilation or enable it

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,4 @@
 ---
-- name: Keystone User - Install dependencies
-  pip: name=python-keystoneclient state=present virtualenv="{{monasca_virtualenv_dir}}"
-  when: not skip_install
-
 - name: Install deps to avoid pip doing compilation or enable it
   apt: name={{item}} state=present
   with_items: dependencies

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,1 +1,0 @@
-virtualenv_pkg: virtualenv

--- a/vars/Ubuntu.yml
+++ b/vars/Ubuntu.yml
@@ -1,1 +1,0 @@
-virtualenv_pkg: python-virtualenv


### PR DESCRIPTION
The proper package for Debian depends on the version of debian, rather
than put all the detailed logic for that here just assume it needs to be
installed and put the installation of virtualenv into the appropriate
playbooks.